### PR TITLE
Deprecation updates

### DIFF
--- a/heroku-review-app-deploy/action.yml
+++ b/heroku-review-app-deploy/action.yml
@@ -30,7 +30,7 @@ runs:
     - name: Generate review app name
       env:
         HEROKU_APP_NAME: ${{ inputs.heroku-app-name }}
-      run: echo "::set-output name=heroku-app-name::review-${HEROKU_APP_NAME:0:15}-${{ github.event.number }}"
+      run: echo "heroku-app-name=review-${HEROKU_APP_NAME:0:15}-${{ github.event.number }}" >> $GITHUB_OUTPUT
       id: review-app-name
       shell: bash
 

--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -46,7 +46,7 @@ runs:
       with:
         node-version: ${{ steps.determine-node-npm-version.outputs.node-version }}
         # cache: 'npm' # This throws errors when package-lock.json is not in repo - use manual setup below until package-lock.json will be used everywhere
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: cache-node-modules
       with:
         path: |

--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -35,11 +35,11 @@ runs:
     - id: determine-node-npm-version
       run: |
         NODE_VERSION=$(jq -r '.engines.node' ./package.json)
-        echo "::set-output name=node-version::${NODE_VERSION/null/14}"
+        echo "node-version=${NODE_VERSION/null/14}" >> $GITHUB_OUTPUT
         NPM_VERSION=$(jq -r '.engines.npm' ./package.json)
-        echo "::set-output name=npm-version::${NPM_VERSION/null/}"
+        echo "npm-version=${NPM_VERSION/null/}" >> $GITHUB_OUTPUT
         NPM_POSTINSTALL=$(jq -r '.scripts.postinstall' ./package.json)
-        echo "::set-output name=npm-postinstall::${NPM_POSTINSTALL/null/}"
+        echo "npm-postinstall=${NPM_POSTINSTALL/null/}" >> $GITHUB_OUTPUT
       shell: bash
     - name: Use Node.js
       uses: actions/setup-node@v3
@@ -96,7 +96,7 @@ runs:
     # Update package-lock.json as artifact if someone forgot to push it
     - name: Check if package-lock.json has updates
       id: package-lock-status
-      run: echo "::set-output name=package-changed::$(git status | grep package-lock.json | wc -l)" 
+      run: echo "package-changed=$(git status | grep package-lock.json | wc -l)" >> $GITHUB_OUTPUT
       shell: bash
 
     - if: ${{ steps.package-lock-status.outputs.package-changed == '1' && inputs.gh-ssh-private-key != '' && github.ref_protected != true }}
@@ -109,10 +109,10 @@ runs:
     - if: ${{ steps.package-lock-status.outputs.package-changed == '1' && inputs.gh-ssh-private-key == '' && github.ref_protected != true && github.actor != 'dependabot[bot]' }}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
-        commit_message: Updated package-lock.json. Please trigger workflow again to run check.
+        commit_message: "[skip ci] Updated package-lock.json. Please trigger workflow again to run check."
         file_pattern: "package-lock.json"
         disable_globbing: true
 
     - if: ${{ steps.package-lock-status.outputs.package-changed == '1' && github.ref_protected == true }}
-      run: echo "package-lock.json has been updated in this run, but changes cannot be pushed to protected branch"
+      run: echo "[skip ci] package-lock.json has been updated in this run, but changes cannot be pushed to protected branch"
       shell: bash

--- a/temp
+++ b/temp
@@ -1,4 +1,0 @@
-
-Everything up-to-date
-Everything up-to-date
-


### PR DESCRIPTION
Fixing: 
```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```