### PR TITLE
Use exact npm and node version from package.json

### DIFF
--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -34,6 +34,7 @@ runs:
         ssh-key: ${{ inputs.gh-ssh-private-key }}
     - id: determine-node-npm-version
       run: |
+        # tr-d '<=>' to trim '>=8.19.x' to '8.19.x' to prevent major version bumps (like npm@9.3.0 installed by npm i npm@>=8.19.x)
         NODE_VERSION=$(jq -r '.engines.node' ./package.json | tr -d '<=>')
         echo "node-version=${NODE_VERSION/null/14}" >> $GITHUB_OUTPUT
         NPM_VERSION=$(jq -r '.engines.npm' ./package.json | tr -d '<=>')

--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -34,9 +34,9 @@ runs:
         ssh-key: ${{ inputs.gh-ssh-private-key }}
     - id: determine-node-npm-version
       run: |
-        NODE_VERSION=$(jq -r '.engines.node' ./package.json)
+        NODE_VERSION=$(jq -r '.engines.node' ./package.json | tr -d '<=>')
         echo "node-version=${NODE_VERSION/null/14}" >> $GITHUB_OUTPUT
-        NPM_VERSION=$(jq -r '.engines.npm' ./package.json)
+        NPM_VERSION=$(jq -r '.engines.npm' ./package.json | tr -d '<=>')
         echo "npm-version=${NPM_VERSION/null/}" >> $GITHUB_OUTPUT
         NPM_POSTINSTALL=$(jq -r '.scripts.postinstall' ./package.json)
         echo "npm-postinstall=${NPM_POSTINSTALL/null/}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This is to avoid issues when `package.json` defines `npm` version as `>=8.19.x` which installs latest version that meets this condition - as of today it is `9.3.0` which apparently has some issue with removing `.bin` dir from `node_modules` in `npm ci` command
![image](https://user-images.githubusercontent.com/100693724/212333941-2ba46378-5179-49e0-84c9-7dcb69cf9428.png)

![image](https://user-images.githubusercontent.com/100693724/212333993-6a9db4df-ee2c-41a6-8f9b-ded448d1d44b.png)
