### PR TITLE
Fail workflow when npmrc is empty

### DIFF
--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -28,6 +28,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Validate npmrc
+      if: inputs.npmrc == ''
+      run: |
+        echo "::error::npmrc is empty. Please set it in Actions and/or Dependabot secrets"
+        exit 1
+      shell: bash
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.head_ref }}


### PR DESCRIPTION
This would fail before tests so it will remind us to set secrets.

Example https://github.com/sumup/invoices-data-archival/pull/36 
<img width="729" alt="image" src="https://user-images.githubusercontent.com/100693724/212913812-039bef41-8df8-4630-a366-8cc4999178a8.png">
