### PR TITLE
Docker build configure path

### DIFF
--- a/build-and-push-docker-image/action.yml
+++ b/build-and-push-docker-image/action.yml
@@ -19,7 +19,7 @@ inputs:
     required: true
   dockerfilePath:
     description: Path to Dockerfile if different than root
-    default: './Dockerfile'
+    required: false
 
 runs:
   using: "composite"

--- a/build-and-push-docker-image/action.yml
+++ b/build-and-push-docker-image/action.yml
@@ -17,6 +17,9 @@ inputs:
   gh-ssh-private-key-b64:
     description: 'Base64 encoded GH private key'
     required: true
+  dockerfilePath:
+    description: Path to Dockerfile if different than root
+    default: './Dockerfile'
 
 runs:
   using: "composite"
@@ -34,6 +37,7 @@ runs:
       uses: docker/build-push-action@v2
       with:
         push: true
+        file: ${{ dockerfilePath }}
         build-args: |
           NPMRC=${{ inputs.npmrc }}
           ssh_prv_key=${{ inputs.gh-ssh-private-key-b64 }}

--- a/build-and-push-docker-image/action.yml
+++ b/build-and-push-docker-image/action.yml
@@ -37,7 +37,7 @@ runs:
       uses: docker/build-push-action@v2
       with:
         push: true
-        file: ${{ dockerfilePath }}
+        file: ${{ inputs.dockerfilePath }}
         build-args: |
           NPMRC=${{ inputs.npmrc }}
           ssh_prv_key=${{ inputs.gh-ssh-private-key-b64 }}


### PR DESCRIPTION
This is needed to handle different path for Dockerfile introduced in https://github.com/debitoor/debitoor-api/pull/4988

We still need this action to build and push a few Docker images to Debitoor AWS ECR that are mainly used in `debitoor-api` CI.
Later we can switch CI to images we also have in SumUp AWS ECR and this action will be redundant.