### PR TITLE
Added .cache/puppeteer to cache

### DIFF
--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -62,6 +62,7 @@ runs:
           !node_modules/**/node_modules
           **/node_modules
           ~/.cache/Cypress
+          ~/.cache/puppeteer
         key: ${{ runner.os }}-modules-${{ hashFiles('package.json') }}
         restore-keys: |
           ${{ runner.os }}-modules-${{ hashFiles('package.json') }}


### PR DESCRIPTION
This is to fix puppeteer issues when cache is used instead of running `npm install` command. 

Example from failed workflow:
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/100693724/217470212-ed676b32-391a-4209-8f74-91f40fb1d548.png">


<img width="892" alt="image" src="https://user-images.githubusercontent.com/100693724/217470130-82a815d9-3846-4e8e-8b85-c7036615892d.png">
