### PR TITLE
Report deployment status to Github

### DIFF
--- a/deployment-status/action.yml
+++ b/deployment-status/action.yml
@@ -1,0 +1,48 @@
+name: 'Update deployment status'
+description: 'Workflow to manage Github deployment statuses'
+
+inputs:
+  state:
+    description: 'Deployment state'
+    default: 'pending'
+    required: false
+  environment:
+    description: 'Environment that is deployed'
+    default: 'production'
+    required: false
+  deployment-id:
+    description: 'Deployment ID'
+    required: false
+outputs:
+  deployment-id:
+    description: "Deployment ID"
+    value: ${{ steps.create-deployment.outputs.deployment-id }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: create-deployment
+      if: inputs.state == 'pending'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        PAYLOAD="{\"ref\": \"${{ github.ref }}\",\"environment\": \"${{ inputs.environment }}\", \"required_contexts\": []}"
+        
+        echo deployment-id=$(echo "$PAYLOAD" | gh api \
+          --method POST \
+          -H "Accept: application/vnd.github+json" \
+          /repos/${{ github.repository }}/deployments \
+          --jq ".id" \
+          --input -) >> $GITHUB_OUTPUT
+      shell: bash
+    
+    - if: inputs.state != 'pending'
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh api \
+        --method POST \
+        -H "Accept: application/vnd.github+json" \
+        /repos/${{ github.repository }}/deployments/${{ inputs.deployment-id }}/statuses \
+        -f state=${{ inputs.state }} \
+      shell: bash

--- a/deployment-status/action.yml
+++ b/deployment-status/action.yml
@@ -3,12 +3,12 @@ description: 'Workflow to manage Github deployment statuses'
 
 inputs:
   state:
-    description: 'Deployment state'
+    description: 'Deployment state. One of: error, failure, inactive, in_progress, queued, pending, success'
     default: 'pending'
     required: false
   environments:
     default: 'production'
-    description: ''
+    description: 'Comma separated environments used for deployment'
     required: false
 
 runs:

--- a/deployment-status/action.yml
+++ b/deployment-status/action.yml
@@ -6,43 +6,57 @@ inputs:
     description: 'Deployment state'
     default: 'pending'
     required: false
-  environment:
-    description: 'Environment that is deployed'
+  environments:
     default: 'production'
+    description: ''
     required: false
-  deployment-id:
-    description: 'Deployment ID'
-    required: false
-outputs:
-  deployment-id:
-    description: "Deployment ID"
-    value: ${{ steps.create-deployment.outputs.deployment-id }}
 
 runs:
   using: "composite"
   steps:
-    - id: create-deployment
-      if: inputs.state == 'pending'
+    - name: Update deployment
+      run: |
+        for env_name in $(echo "${envs}" | tr ',' '\n')
+        do
+          echo "${env_name}"
+          deployment_id_var=${env_name//-/_}_deployment_id
+          if [[ ${!deployment_id_var} != "" ]]
+          then
+            echo "Updating Deployment ${env_name} --> ${{ inputs.state }}"
+            
+            gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/deployments/${!deployment_id_var}/statuses \
+            -f state=${{ inputs.state }}
+          fi
+        done
       env:
         GH_TOKEN: ${{ github.token }}
-      run: |
-        PAYLOAD="{\"ref\": \"${{ github.ref }}\",\"environment\": \"${{ inputs.environment }}\", \"required_contexts\": []}"
-        
-        echo deployment-id=$(echo "$PAYLOAD" | gh api \
-          --method POST \
-          -H "Accept: application/vnd.github+json" \
-          /repos/${{ github.repository }}/deployments \
-          --jq ".id" \
-          --input -) >> $GITHUB_OUTPUT
+        envs: ${{ inputs.environments }}
       shell: bash
-    
-    - if: inputs.state != 'pending'
+
+    - name: Create deployment
+      run: |
+        for env_name in $(echo "${envs}" | tr ',' '\n')
+        do
+          echo "${env_name}"
+          deployment_id_var=${env_name//-/_}_deployment_id
+          if [[ ${!deployment_id_var} == "" ]]
+          then
+            echo "Creating Deployment ${env_name} --> ${{ inputs.state }}"
+            PAYLOAD="{\"ref\": \"${{ github.ref }}\",\"environment\": \"${env_name}\", \"required_contexts\": []}"
+            
+            echo ${deployment_id_var}=$(echo "$PAYLOAD" | gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              /repos/${{ github.repository }}/deployments \
+              --jq ".id" \
+              --input -) >> $GITHUB_ENV
+          fi
+        done
       env:
         GH_TOKEN: ${{ github.token }}
-      run: |
-        gh api \
-        --method POST \
-        -H "Accept: application/vnd.github+json" \
-        /repos/${{ github.repository }}/deployments/${{ inputs.deployment-id }}/statuses \
-        -f state=${{ inputs.state }} \
+        envs: ${{ inputs.environments }}
       shell: bash
+   

--- a/deployment-status/action.yml
+++ b/deployment-status/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: 'pending'
     required: false
   environments:
-    default: 'production'
+    default: 'fleet-live'
     description: 'Comma separated environments used for deployment'
     required: false
 

--- a/deployment-status/action.yml
+++ b/deployment-status/action.yml
@@ -14,49 +14,43 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Update deployment
+    - name: Create/Update deployment
       run: |
         for env_name in $(echo "${envs}" | tr ',' '\n')
         do
           echo "${env_name}"
-          deployment_id_var=${env_name//-/_}_deployment_id
-          if [[ ${!deployment_id_var} != "" ]]
+          echo "Checking for existing deployment for sha ${{ github.sha }}"
+
+          deployment_id=$(gh api \
+            --method GET \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/deployments \
+            -f environment="${env_name}" \
+            -f sha="${{ github.sha }}" \
+            --jq '.[-1].id')
+
+          if [[ ${deployment_id} != "" ]]
           then
             echo "Updating Deployment ${env_name} --> ${{ inputs.state }}"
-            
+
             gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
-            /repos/${{ github.repository }}/deployments/${!deployment_id_var}/statuses \
+            /repos/${{ github.repository }}/deployments/${deployment_id}/statuses \
             -f state=${{ inputs.state }}
-          fi
-        done
-      env:
-        GH_TOKEN: ${{ github.token }}
-        envs: ${{ inputs.environments }}
-      shell: bash
-
-    - name: Create deployment
-      run: |
-        for env_name in $(echo "${envs}" | tr ',' '\n')
-        do
-          echo "${env_name}"
-          deployment_id_var=${env_name//-/_}_deployment_id
-          if [[ ${!deployment_id_var} == "" ]]
-          then
+          else
             echo "Creating Deployment ${env_name} --> ${{ inputs.state }}"
+
+            # workaround for GH CLI not handling empty arrays as parameters
             PAYLOAD="{\"ref\": \"${{ github.ref }}\",\"environment\": \"${env_name}\", \"required_contexts\": []}"
-            
-            echo ${deployment_id_var}=$(echo "$PAYLOAD" | gh api \
+            echo "$PAYLOAD" | gh api \
               --method POST \
               -H "Accept: application/vnd.github+json" \
               /repos/${{ github.repository }}/deployments \
-              --jq ".id" \
-              --input -) >> $GITHUB_ENV
+              --input -
           fi
         done
       env:
         GH_TOKEN: ${{ github.token }}
         envs: ${{ inputs.environments }}
       shell: bash
-   


### PR DESCRIPTION
This action will report deployment status to Github using GH CLI. 

Usage:
[Configure GH Token permissions --> .github/workflows/cd.yaml#L37](https://github.com/sumup/invoices-data-archival/blob/a93b670d7c449d0ad8565bb19e763d025103f349/.github/workflows/cd.yaml#L37)
[Create deployment --> .github/workflows/cd.yaml#L54-L56](https://github.com/sumup/invoices-data-archival/blob/a93b670d7c449d0ad8565bb19e763d025103f349/.github/workflows/cd.yaml#L54-L56)
[Update status on success --> .github/workflows/cd.yaml#L106-L109](https://github.com/sumup/invoices-data-archival/blob/a93b670d7c449d0ad8565bb19e763d025103f349/.github/workflows/cd.yaml#L106-L109)
[Update status on failure --> .github/workflows/cd.yaml#L111-L115](https://github.com/sumup/invoices-data-archival/blob/a93b670d7c449d0ad8565bb19e763d025103f349/.github/workflows/cd.yaml#L111-L115)