### PR TITLE
Replace .npmrc with npm tokens

### DIFF
--- a/.github/workflows/tag-main.yml
+++ b/.github/workflows/tag-main.yml
@@ -24,7 +24,7 @@ jobs:
         
       - name: Tag source
         env:
-          TAG_NAME: ${{ inputs.tag-name || 'v1' }}
+          TAG_NAME: ${{ inputs.tag-name || 'v2' }}
         run: git tag -f -am "$TAG_NAME" $TAG_NAME
 
       - name: Push tag

--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -2,9 +2,12 @@ name: 'Run NPM install'
 description: 'Workflow to execute npm install script'
 
 inputs:
-  npmrc:
-    description: 'NPMRC'
+  debitoor-npm-token:
+    description: 'NPM token for Debitoor packages'
     required: true
+  sumup-npm-token:
+    description: 'NPM token for SumUp packages'
+    required: false
   gh-ssh-private-key:
     description: 'SSH private key'
     required: false
@@ -22,16 +25,15 @@ inputs:
   npm-command-flags:
     description: run npm command with additional flags
     required: false
-    example: --legacy-peer-deps --omit=dev
     default: ""
 
 runs:
   using: "composite"
   steps:
-    - name: Validate npmrc
-      if: inputs.npmrc == ''
+    - name: Validate debitoor NPM token
+      if: inputs.debitoor-npm-token == ''
       run: |
-        echo "::error::npmrc is empty. Please set it in Actions and/or Dependabot secrets"
+        echo "::error::debitoor-npm-token is empty. Please set it in Actions and/or Dependabot secrets"
         exit 1
       shell: bash
     - uses: actions/checkout@v3
@@ -73,10 +75,18 @@ runs:
       shell: bash
 
     # Configure credentials
-    - name: Create NPMRC
+    - name: Configure debitoor token
       env:
-        NPMRC: ${{ inputs.npmrc }}
-      run: echo "$NPMRC" > .npmrc
+        debitoor_npm_token: ${{ inputs.debitoor-npm-token }}
+      run: echo "//registry.npmjs.org/:_authToken=${debitoor_npm_token}" > .npmrc
+      shell: bash
+    - name: Configure debitoor token
+      if: inputs.sumup-npm-token != ''
+      env:
+        sumup_npm_token: ${{ inputs.sumup-npm-token }}
+      run: |
+        echo "@sumup:registry=https://npm.pkg.github.com" >> .npmrc
+        echo "//npm.pkg.github.com/:_authToken=${sumup_npm_token}" >> .npmrc
       shell: bash
     - name: Install SSH Key
       if: inputs.gh-ssh-private-key != ''

--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -3,10 +3,10 @@ description: 'Workflow to execute npm install script'
 
 inputs:
   debitoor-npm-token:
-    description: 'NPM token for Debitoor packages'
+    description: 'NPM token for @debitoor scoped packages'
     required: true
   sumup-npm-token:
-    description: 'NPM token for SumUp packages'
+    description: 'NPM token for @sumup scoped packages'
     required: false
   gh-ssh-private-key:
     description: 'SSH private key'

--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -75,12 +75,12 @@ runs:
       shell: bash
 
     # Configure credentials
-    - name: Configure debitoor token
+    - name: Configure Debitoor token
       env:
         debitoor_npm_token: ${{ inputs.debitoor-npm-token }}
       run: echo "//registry.npmjs.org/:_authToken=${debitoor_npm_token}" > .npmrc
       shell: bash
-    - name: Configure debitoor token
+    - name: Configure SumUp token
       if: inputs.sumup-npm-token != ''
       env:
         sumup_npm_token: ${{ inputs.sumup-npm-token }}


### PR DESCRIPTION
Dependabot needs tokens, not the whole `.npmrc` content. 
So instead of keeping secrets for `NPMRC`, `DEBITOOR_NPM_TOKEN`, `SUMUP_NPM_TOKEN` let's switch to tokens and stop using `NPMRC`