### PR TITLE
[npm-install] update lockfile only for texts

### DIFF
--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -117,14 +117,14 @@ runs:
       run: echo "package-changed=$(git status | grep package-lock.json | wc -l)" >> $GITHUB_OUTPUT
       shell: bash
 
-    - if: ${{ steps.package-lock-status.outputs.package-changed == '1' && inputs.gh-ssh-private-key != '' && github.ref_protected != true && github.actor != 'dependabot[bot]' && contains(github.event.pull_request.title, 'texts') }}
+    - if: ${{ steps.package-lock-status.outputs.package-changed == '1' && inputs.gh-ssh-private-key != '' && github.ref_protected != true && github.actor != 'dependabot[bot]' && contains(github.event.pull_request.title, '-texts') }}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Updated package-lock.json
         file_pattern: "package-lock.json"
         disable_globbing: true
 
-    - if: ${{ github.event.number != '' && steps.package-lock-status.outputs.package-changed == '1' && inputs.gh-ssh-private-key == '' && github.ref_protected != true && github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.title, 'texts') }}
+    - if: ${{ github.event.number != '' && steps.package-lock-status.outputs.package-changed == '1' && inputs.gh-ssh-private-key == '' && github.ref_protected != true && github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.title, '-texts') }}
       name: Comment outdated package-lock.json
       uses: peter-evans/create-or-update-comment@v2
       with:

--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -117,14 +117,14 @@ runs:
       run: echo "package-changed=$(git status | grep package-lock.json | wc -l)" >> $GITHUB_OUTPUT
       shell: bash
 
-    - if: ${{ steps.package-lock-status.outputs.package-changed == '1' && inputs.gh-ssh-private-key != '' && github.ref_protected != true && github.actor != 'dependabot[bot]' }}
+    - if: ${{ steps.package-lock-status.outputs.package-changed == '1' && inputs.gh-ssh-private-key != '' && github.ref_protected != true && github.actor != 'dependabot[bot]' && contains(github.event.pull_request.title, 'texts') }}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Updated package-lock.json
         file_pattern: "package-lock.json"
         disable_globbing: true
 
-    - if: ${{ github.event.number != '' && steps.package-lock-status.outputs.package-changed == '1' && inputs.gh-ssh-private-key == '' && github.ref_protected != true && github.actor != 'dependabot[bot]' }}
+    - if: ${{ github.event.number != '' && steps.package-lock-status.outputs.package-changed == '1' && inputs.gh-ssh-private-key == '' && github.ref_protected != true && github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.title, 'texts') }}
       name: Comment outdated package-lock.json
       uses: peter-evans/create-or-update-comment@v2
       with:


### PR DESCRIPTION
Update lockfile only for texts packages updates. In other cases developer should take care of commiting updated lockfile.

Example of texts update PRs: 
<img width="788" alt="image" src="https://github.com/debitoor/nodejs-action/assets/100693724/431f778d-afd2-4fb4-ae06-a1aaf05f4bdd">
