### PR TITLE
Use npm ci as default way of installing dependencies

### DIFF
--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -94,10 +94,13 @@ runs:
       with:
         key: ${{ inputs.gh-ssh-private-key }} 
         known_hosts: ${{ inputs.gh-ssh-known-hosts }}
+
+    # Updates by Bob should always run `npm install`
     - name: NPM Install
       if: (github.actor == 'bobhammer' || inputs.npm-ci-install == 'false') && steps.cache-node-modules.outputs.cache-hit != 'true'
       run: npm install ${{ inputs.npm-command-flags }}
       shell: bash
+    # Updates from other users should run `npm ci` unless `npm-ci-install` has been set to false
     - name: NPM CI
       if: github.actor != 'bobhammer' && inputs.npm-ci-install == 'true' && steps.cache-node-modules.outputs.cache-hit != 'true'
       run: npm ci ${{ inputs.npm-command-flags }}
@@ -106,38 +109,38 @@ runs:
       if: ${{ failure() }}
       run: cat ~/.npm/_logs/*
       shell: bash
+
     - name: Check outdated lockfile
       id: outdated-lockfile
       if: ${{ failure() }}
       run: echo "outdated-lockfile=$(grep 'Please update your lock file with' ~/.npm/_logs/*debug*.log | wc -l)" >> $GITHUB_OUTPUT
       shell: bash
+
     - name: NPM postinstall script
-      if: steps.determine-node-npm-version.outputs.npm-postinstall != '' && steps.cache-node-modules.outputs.cache-hit == 'true'
+      if: inputs.npm-ci-install == 'false' && steps.determine-node-npm-version.outputs.npm-postinstall != '' && steps.cache-node-modules.outputs.cache-hit == 'true'
       run: npm run postinstall
       shell: bash
 
-    # Update package-lock.json as artifact if someone forgot to push it
+    # Update package-lock.json after `npm install`
     - name: Check if package-lock.json has updates
       id: package-lock-status
       run: echo "package-changed=$(git status | grep package-lock.json | wc -l)" >> $GITHUB_OUTPUT
       shell: bash
 
-    - if: ${{ steps.package-lock-status.outputs.package-changed == '1' && inputs.gh-ssh-private-key != '' && github.ref_protected != true && github.actor != 'dependabot[bot]' && contains(github.event.pull_request.title, '-texts') }}
+    # Commit package-lock.json if it has been updated (only for Bob's PRs) AND SSH key was provided (so PR checks can be triggered again)
+    - if: ${{ steps.package-lock-status.outputs.package-changed == '1' && inputs.gh-ssh-private-key != '' && github.ref_protected != true && github.actor == 'bobhammer' }}
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         commit_message: Updated package-lock.json
         file_pattern: "package-lock.json"
         disable_globbing: true
 
-    - if: ${{ always() && github.event.number != '' && (steps.package-lock-status.outputs.package-changed == '1' || steps.outdated-lockfile.outputs.outdated-lockfile != '0') && inputs.gh-ssh-private-key == '' && github.ref_protected != true && github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.title, '-texts') }}
+    # Comment regarding outdated lockfile
+    - if: ${{ always() && github.event.number != '' && steps.outdated-lockfile.outputs.outdated-lockfile != '0' && github.actor != 'bobhammer' }}
       name: Comment outdated package-lock.json
       uses: peter-evans/create-or-update-comment@v2
       with:
         issue-number: ${{ github.event.number }}
         body: |
-          `package-lock.json` seems to be not in sync with `package.json`. 
-          Please commit updated `package-lock.json` file (otherwise deployment might fail).
-
-    - if: ${{ steps.package-lock-status.outputs.package-changed == '1' && github.ref_protected == true }}
-      run: echo "package-lock.json has been updated in this run, but changes cannot be pushed to protected branch"
-      shell: bash
+          `package-lock.json` is not in sync with `package.json`. 
+          Please commit updated `package-lock.json` file (otherwise deployment will fail).

--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -142,8 +142,13 @@ runs:
       with:
         issue-number: ${{ github.event.number }}
         body: |
-          `package-lock.json` has been updated in recent CI workflow run, but cannot be commited because of missing SSH key.
-          Please run `npm install` and commit updated `package-lock.json` file or provide SSH key in `gh-ssh-private-key`.
+          `package-lock.json` has been updated in recent CI workflow run, but cannot be committed because of missing SSH key.
+          Please run `npm install` and commit updated `package-lock.json` file or provide SSH key in CI workflow as `gh-ssh-private-key`.
+
+    - if: ${{ steps.package-lock-status.outputs.package-changed == '1' && inputs.gh-ssh-private-key == '' && github.ref_protected != true && github.actor == 'bobhammer' }}
+      name: Fail because of outdated package-lock.json
+      run: exit 1
+      shell: bash
 
     # Comment regarding outdated lockfile
     - if: ${{ always() && github.event.number != '' && steps.outdated-lockfile.outputs.outdated-lockfile != '0' && github.actor != 'bobhammer' }}

--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -129,7 +129,7 @@ runs:
         file_pattern: "package-lock.json"
         disable_globbing: true
 
-    - if: ${{ github.event.number != '' && (steps.package-lock-status.outputs.package-changed == '1' || steps.outdated-lockfile.outputs.outdated-lockfile != '0') && inputs.gh-ssh-private-key == '' && github.ref_protected != true && github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.title, '-texts') }}
+    - if: ${{ always() && github.event.number != '' && (steps.package-lock-status.outputs.package-changed == '1' || steps.outdated-lockfile.outputs.outdated-lockfile != '0') && inputs.gh-ssh-private-key == '' && github.ref_protected != true && github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.title, '-texts') }}
       name: Comment outdated package-lock.json
       uses: peter-evans/create-or-update-comment@v2
       with:

--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -135,6 +135,16 @@ runs:
         file_pattern: "package-lock.json"
         disable_globbing: true
 
+    # Comment regarding updated lockfile when SSH key is not provided
+    - if: ${{ steps.package-lock-status.outputs.package-changed == '1' && inputs.gh-ssh-private-key == '' && github.ref_protected != true && github.actor == 'bobhammer' }}
+      name: Comment updated package-lock.json
+      uses: peter-evans/create-or-update-comment@v2
+      with:
+        issue-number: ${{ github.event.number }}
+        body: |
+          `package-lock.json` has been updated in recent CI workflow run, but cannot be commited because of missing SSH key.
+          Please run `npm install` and commit updated `package-lock.json` file or provide SSH key in `gh-ssh-private-key`.
+
     # Comment regarding outdated lockfile
     - if: ${{ always() && github.event.number != '' && steps.outdated-lockfile.outputs.outdated-lockfile != '0' && github.actor != 'bobhammer' }}
       name: Comment outdated package-lock.json

--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -17,7 +17,7 @@ inputs:
   npm-ci-install:
     description: 'Run npm ci instead of npm i'
     required: false
-    default: 'false'
+    default: 'true'
   skip-package-lock-commit:
     description: 'Set to true to skip committing package-lock.json'
     required: false
@@ -95,11 +95,11 @@ runs:
         key: ${{ inputs.gh-ssh-private-key }} 
         known_hosts: ${{ inputs.gh-ssh-known-hosts }}
     - name: NPM Install
-      if: inputs.npm-ci-install == 'false' && steps.cache-node-modules.outputs.cache-hit != 'true'
+      if: (github.actor == 'bobhammer' || inputs.npm-ci-install == 'false') && steps.cache-node-modules.outputs.cache-hit != 'true'
       run: npm install ${{ inputs.npm-command-flags }}
       shell: bash
     - name: NPM CI
-      if: inputs.npm-ci-install == 'true' && steps.cache-node-modules.outputs.cache-hit != 'true'
+      if: github.actor != 'bobhammer' && inputs.npm-ci-install == 'true' && steps.cache-node-modules.outputs.cache-hit != 'true'
       run: npm ci ${{ inputs.npm-command-flags }}
       shell: bash
     - name: Print debug logs

--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -110,6 +110,8 @@ runs:
       run: cat ~/.npm/_logs/*
       shell: bash
 
+    # `npm ci` fails if package-lock.json file had been not committed after updating package.json
+    # This step looks for such error in logs from `npm ci` so later we can add a comment regarding this to PR
     - name: Check outdated lockfile
       id: outdated-lockfile
       if: ${{ failure() }}

--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -106,6 +106,11 @@ runs:
       if: ${{ failure() }}
       run: cat ~/.npm/_logs/*
       shell: bash
+    - name: Check outdated lockfile
+      id: outdated-lockfile
+      if: ${{ failure() }}
+      run: echo "outdated-lockfile=$(grep 'Please update your lock file with' ~/.npm/_logs/*debug*.log | wc -l)" >> $GITHUB_OUTPUT
+      shell: bash
     - name: NPM postinstall script
       if: steps.determine-node-npm-version.outputs.npm-postinstall != '' && steps.cache-node-modules.outputs.cache-hit == 'true'
       run: npm run postinstall
@@ -124,7 +129,7 @@ runs:
         file_pattern: "package-lock.json"
         disable_globbing: true
 
-    - if: ${{ github.event.number != '' && steps.package-lock-status.outputs.package-changed == '1' && inputs.gh-ssh-private-key == '' && github.ref_protected != true && github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.title, '-texts') }}
+    - if: ${{ github.event.number != '' && (steps.package-lock-status.outputs.package-changed == '1' || steps.outdated-lockfile.outputs.outdated-lockfile != '0') && inputs.gh-ssh-private-key == '' && github.ref_protected != true && github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.title, '-texts') }}
       name: Comment outdated package-lock.json
       uses: peter-evans/create-or-update-comment@v2
       with:


### PR DESCRIPTION
https://sumupteam.atlassian.net/browse/IA-8851

## Tested:
### When developer updates both `package.json` and `package-lock.json` and workflow will use `npm ci`
<img width="1049" alt="image" src="https://github.com/debitoor/nodejs-action/assets/100693724/d6254774-f88c-4cf8-9f6a-ab33560b4d1b">

---

### When developer updates only `package.json` and workflow will use `npm ci`
<img width="1041" alt="image" src="https://github.com/debitoor/nodejs-action/assets/100693724/8f380398-a84a-4fc4-930d-1262676ffa0f">

----

### When Bob updates only `package.json`, but SSH key is not set, so workflow will continue to use `npm install`, but won't be able to commit updated lockfile
<img width="962" alt="image" src="https://github.com/debitoor/nodejs-action/assets/100693724/1959b339-1e0a-4936-bf96-65cc516a2293">

---

### When Bob updates only `package.json` and SSH is set, so workflow will continue to use `npm install` and will commit updated lockfile
<img width="967" alt="image" src="https://github.com/debitoor/nodejs-action/assets/100693724/dbf6d2ef-395b-490e-872e-23c12149ed7a">
