### PR TITLE
Use multiple package.json files as cache key

### DIFF
--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -65,9 +65,9 @@ runs:
           **/node_modules
           ~/.cache/Cypress
           .cache/puppeteer
-        key: ${{ runner.os }}-modules-${{ hashFiles('package.json') }}
+        key: ${{ runner.os }}-modules-${{ hashFiles('**/package.json') }}
         restore-keys: |
-          ${{ runner.os }}-modules-${{ hashFiles('package.json') }}
+          ${{ runner.os }}-modules-${{ hashFiles('**/package.json') }}
           ${{ runner.os }}-modules-
     - name: Update NPM
       if: steps.determine-node-npm-version.outputs.npm-version != ''


### PR DESCRIPTION
Using only main `package.json` file makes `npm install` command to be skipped if no changes are detected in the file.
In monorepos there can be more `package.json` files so cache needs to be based on all of the files