### PR TITLE
fix: 🐛 compare only major version to determine outdated node

### DIFF
--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -164,8 +164,8 @@ runs:
       shell: bash
       env:
         NODE_VERSION: ${{ steps.determine-node-npm-version.outputs.node-version }}
-      # bash can only compare integers, use 'bc' to compare versions like 18.20. Also remove '.x' wildcards that we commonly use in version
-      run: echo outdated-node-version=$(echo "${NODE_VERSION//.x/} < 18" | bc) >> $GITHUB_OUTPUT
+      # remove anything after the first dot from NODE_VERSION and then compare it. 'bc' returns 1 if condition is true
+      run: echo outdated-node-version=$(echo "${NODE_VERSION//.*/} < 18" | bc) >> $GITHUB_OUTPUT
 
     - if: always() && fromJSON(steps.determine-old-node-version.outputs.outdated-node-version)
       name: Comment old NodeJs version


### PR DESCRIPTION
Previous approach was working fine for versions like `18.10` or `18.10.x` because we were comparing `18.10` with `18`, but it was failing for versions like `18.10.0` because it tried to compare `18.10.0 < 18` while `18.10.0` is not a valid number 😅 