### PR TITLE
bump actions-cache v4.2.0

### DIFF
--- a/npm-install/action.yml
+++ b/npm-install/action.yml
@@ -55,7 +55,7 @@ runs:
       with:
         node-version: ${{ steps.determine-node-npm-version.outputs.node-version }}
         # cache: 'npm' # This throws errors when package-lock.json is not in repo - use manual setup below until package-lock.json will be used everywhere
-    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+    - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
       id: cache-node-modules
       with:
         path: |


### PR DESCRIPTION
Bumping from deprecated version as documented in https://github.com/actions/cache/releases/tag/v4.2.0